### PR TITLE
Use CssShortener from options, if supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
 # Change Log
+
+## 1.1.0
+
+- Add ability to pass an existing [CssShortener](https://github.com/mbrandau/css-shortener) in options to use for generating and mapping class names
+
+## 1.0.0
+
+- Initial release
+
 This project adheres to [Semantic Versioning](http://semver.org/).

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = postcss.plugin(
                 'A callback is required to return the mapped class names'
             );
 
-        const shortener = new CssShortener();
+        const shortener = opts.cssShortener || new CssShortener();
         const processor = parser(selectors => {
             selectors.walkClasses(classNode => {
                 classNode.value = shortener.getNewClassName(classNode.value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-class-name-shortener",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-class-name-shortener",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PostCSS plugin that shortens CSS class names to optimize website performance.",
   "keywords": [
     "postcss",


### PR DESCRIPTION
Add ability to pass an existing [CssShortener](https://github.com/mbrandau/css-shortener) in options to use for generating and mapping class names